### PR TITLE
Add pip upgrade command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
 RUN mkdir -p /fastapi-admin
 WORKDIR /fastapi-admin
 COPY pyproject.toml poetry.lock /fastapi-admin/
+RUN pip install --upgrade pip
 RUN pip3 install poetry
 ENV POETRY_VIRTUALENVS_CREATE false
 RUN poetry install --no-root


### PR DESCRIPTION
Add pip upgrade command to avoid getting error while docker-compose build phase. Error output below.

error: can't find Rust compiler
  
  If you are using an outdated pip version, it is possible a prebuilt wheel is available for this package but pip is not able to install from it. Installing from the wheel would avoid the need for a Rust compiler.
  
  To update pip, run:
  
      pip install --upgrade pip
  
  and then retry package installation.
  
  If you did intend to build this package from source, try installing a Rust compiler from your system package manager and ensure it is on the PATH during installation. Alternatively, rustup (available at https://rustup.rs) is the recommended way to download and update the Rust compiler toolchain.
