### PR TITLE
Fix menus not pre-selecting current value

### DIFF
--- a/fastapi_admin/templates/widgets/inputs/select.html
+++ b/fastapi_admin/templates/widgets/inputs/select.html
@@ -3,7 +3,7 @@
         <div class="form-label">{{ label }}</div>
         <select class="form-select" name="{{ name }}" id="{{ id }}">
             {% for option in options %}
-                <option value="{{ option[1] }}" {% if option[0] == value %}
+                <option value="{{ option[1] }}" {% if option[1] == value %}
                         selected
                 {% endif %} >{{ option[0] }}</option>
             {% endfor %}

--- a/fastapi_admin/templates/widgets/inputs/select.html
+++ b/fastapi_admin/templates/widgets/inputs/select.html
@@ -1,7 +1,7 @@
 {% with id = 'form-select-' + name %}
     <div class="form-group mb-3">
         <div class="form-label">{{ label }}</div>
-        <select class="form-select" name="{{ name }}" id="{{ id }}">
+        <select class="form-select" autocomplete="off" name="{{ name }}" id="{{ id }}">
             {% for option in options %}
                 <option value="{{ option[1] }}" {% if option[1] == value %}
                         selected


### PR DESCRIPTION
Select menus (enums and ForeignKeys) always default to the first element when editing instead of the current value. This was fixed by comparing `value` to the correct tuple value.

In addition, `autocomplete="off"` was added to fix a [Firefox bug](https://stackoverflow.com/a/10096033/9263287) ignoring the `selected` tag.