### PR TITLE
Fix ForeignKey select menu

### DIFF
--- a/fastapi_admin/resources.py
+++ b/fastapi_admin/resources.py
@@ -171,8 +171,7 @@ class Model(Resource):
             name = input_.context.get("name")
             if isinstance(input_, inputs.ForeignKey):
                 v = data.getlist(name)[0]
-                model = await input_.model.get(id=v)
-                ret[name] = model
+                ret[name] = int(v) if v else None
                 continue
             if isinstance(input_, inputs.ManyToMany):
                 v = data.getlist(name)


### PR DESCRIPTION
ForeignKey select menus are broken because the wrong value is passed to the Tortoise query.

The query is using `related_id` which is expecting an int, but a model object is being sent instead.

This also fixes a bug caused when nothing is selected (nullable foreign key)